### PR TITLE
Incluye listado de 251 pokémon en la segunda página

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -45,7 +45,9 @@
 
       <p class="second_text">Here you will see all 251 Pokémon from Kanto and Johto generations</p>
 
-      <textarea id="pizarra"></textarea>
+      <div>
+        <p id="pokemon_list"></p>
+      </div>
     </section>
 
     <script src="main.js" type="module"></script>

--- a/src/main.js
+++ b/src/main.js
@@ -1,19 +1,27 @@
 //import { example } from './data.js';
 // import data from './data/lol/lol.js';
-import data from './data/pokemon/pokemon.js';
-
-let array = data.pokemon;
-
-for(let i = 0; i < array.length; i++){
-     console.log(array[i])
-}
-
-document.getElementById("pizarra").innerHTML = data.pokemon[0];
-
-//console.log(data.pokemon);
 // import data from './data/rickandmorty/rickandmorty.js';
 
+import data from './data/pokemon/pokemon.js';
 
+function pokemonList(){
+     let array = data.pokemon;
+     let list = "";
+     for(let i = 0; i < array.length; i++){  
+          list += array[i].num+": "+array[i].name+". Type: "+array[i].type+". Size: "
+          +array[i].size.height+", "+array[i].size.weight+"."+"<br>";
+
+          console.log(array[i].name);
+          console.log(array[i].type);
+          console.log(array[i].size);
+     }
+
+     return list;
+}
+
+document.getElementById("pokemon_list").innerHTML = pokemonList();
+
+console.log(data.pokemon);
 
 document.getElementById("enter_button").addEventListener("click", function(){
      document.getElementById("page_one").style.display = "none";

--- a/src/style.css
+++ b/src/style.css
@@ -71,12 +71,12 @@
 
 .second_header{
     display: flex;
-    padding: 3% 0% 5% 20%;
+    padding: 3% 0% 2% 20%;
 }
 
 #logo2 img{
-    margin-left: 38%;
-    width: 55%;
+    margin-left: 30%;
+    width: 65%;
     /*height: 50%;*/
 }
 
@@ -88,8 +88,8 @@
 .second_text{
     /*position: absolute;*/
     /*width: 55%;
-    height: 100%;*/
-    margin-top: 20%;
+    height: 100%;
+    margin-top: 0%;*/
     text-align: center;
     font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     font-style: normal;
@@ -99,4 +99,16 @@
     color: yellow;
     text-shadow: 0 0 0.5em rgb(11, 7, 250), 0 0 0.5em rgb(40, 54, 255),
             0 0 0.5em rgb(0, 8, 248)
+}
+
+#pokemon_list{
+    text-align: center;
+    font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    font-style: normal;
+    font-weight: bold;
+    font-size: 100%;
+    line-height: 175%;
+    color: #CC0000;
+    /* text-shadow: 0 0 0.5em rgb(11, 7, 250), 0 0 0.5em rgb(40, 54, 255),
+            0 0 0.5em rgb(0, 8, 248) */
 }


### PR DESCRIPTION
Primera página lista.
2 botones (start y return) funcionando.
Segunda página con fondo con opacidad, logo, botón de retorno y texto de explicación (con estilos).
Incluye la lista de los 251 Pokémon con número, nombre, tipo y talla (altura+peso). La función está en main.js